### PR TITLE
Output format documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ otc ecs create-vpc --vpc-name myvpc --cidr 10.0.0.0/8                Crete new V
 otc ecs describe-vpcs                                                List VPCs
 Subnet Commands:
 otc ecs create-subnet --subnet-name subnettest --cidr 192.168.1.0/16 --gateway-ip 192.168.1.2 --primary-dns 8.8.8.8 --secondary-dns 8.8.4.4 --availability-zone eu-de-01 --vpc-name default-vpc    Create new subnet for VPC
-otc ecs describe-subnets --output json
+otc ecs describe-subnets --output Json
 Security Group Commands:
 otc ecs create-security-group --group-name test2 --vpc-name default-vpc  Create new security group
 otc ecs describe-security-groups                                     List existing security-groups
@@ -65,7 +65,7 @@ otc ecs describe-key-pairs                                           List key pa
 otc ecs create-key-pair --key-name mykeypair "ssh-rsa AA..."       Create key pair
 Instance Commands:
 otc ecs describe-instances                                           List VM instances
-otc ecs describe-instances  --instance-ids 097da903-ab95-44f3-bb5d-5fc08dfb6cc3 --output json     Detailed information of specific VM instance (JSON)
+otc ecs describe-instances  --instance-ids 097da903-ab95-44f3-bb5d-5fc08dfb6cc3 --output Json     Detailed information of specific VM instance (JSON)
 otc ecs run-instances --count 1  --admin-pass yourpass123! --instance-type c1.medium --instance-name instancename --image-name Standard_CentOS_6.7_latest --subnet-name testsubnet --vpc-name testvpc --group-name testsecgroup     Create new VM instance and START
 otc ecs run-instances --count 1  --admin-pass yourpass123! --instance-type c1.medium --instance-name instancename --image-name Standard_CentOS_6.7_latest --subnet-name testsubnet --vpc-name testvpc --group-name testsecgroup  --key-name testsshkeypair --file1 /otc/a=/otc/a
 --associate-public-ip-address  --wait-instance-running    Create new VM instance with injected SSH keypair, with public ip, additional file injection, wait instance created and running

--- a/otcclient/shell.py
+++ b/otcclient/shell.py
@@ -172,7 +172,7 @@ def main(argv=None): # IGNORE:C0111
         parser.add_argument( "--portmax",dest="PORTMAX", help="Upper  port of the specific security group rule")
         parser.add_argument( "--protocol",dest="PROTOCOL", help="Protocol of the specific security group rule")
         parser.add_argument( "--ethertype",dest="ETHERTYPE", help="Ethertype of the specific security group rule ")
-        parser.add_argument( "--output",dest="OUTPUT_FORMAT", help="Output format")
+        parser.add_argument( "--output",dest="OUTPUT_FORMAT", choices=['Json', 'table', 'text'], default='table', help="Output format")
         parser.add_argument( "--query",dest="QUERY", help="JSON Path query")
         parser.add_argument( "--size",dest="VOLUME_SIZE", help="Size of the EVS disk")
         parser.add_argument( "--volume-type",dest="VOLUME_TYPE", help="Volume type of the EVS disk [SSD,SAS,SATA]")

--- a/otcclient/shell.py
+++ b/otcclient/shell.py
@@ -217,7 +217,7 @@ def main(argv=None): # IGNORE:C0111
         parser.add_argument( "--healthcheck-interval", dest="HEALTHCHECK_INTERVAL", help="Specifies the maximum interval for health check.The value ranges from 1 to 5(s)")
         parser.add_argument( "--healthcheck-protocol", dest="HEALTHCHECK_PROTOCOL", help="Specifies the health check protocol.The value can be HTTP or TCP (case-insensitive)")
         parser.add_argument( "--healthcheck-timeout", dest="HEALTHCHECK_TIMEOUT", help="Specifies the maximum timeout duration for health check. The value ranges from 1 to 50 (s)")
-        parser.add_argument( "--healthcheck-uri", dest="HEALTHCHECK_URI", help="Specifies the URI for health check. The value is a string of 1 to 80 characters that contain only letters, digits, and special characters (such as -/.%?#&).It must start with /. This parameter is valid when healthcheck_protocol is HTTP.")
+        parser.add_argument( "--healthcheck-uri", dest="HEALTHCHECK_URI", help="Specifies the URI for health check. The value is a string of 1 to 80 characters that contain only letters, digits, and special characters (such as -/.%%?#&).It must start with /. This parameter is valid when healthcheck_protocol is HTTP.")
         parser.add_argument( "--healthy-threahold", dest="HEALTHY_THREAHOLD", help="Specifies the number of consecutive successful health checks for the health check result changing from fail to success. The value ranges from 1 to 10.")
         #LISTENER_ID
         parser.add_argument( "--unhealthy-threshold", dest="UNHEALTHY_THRESHOLD", help="Specifies the number of consecutive successful health checks for the health check result changing from success to fail. The value ranges from 1 to 10.")


### PR DESCRIPTION
Give more information on output formats

The README.md incorrectly mentions '--output json', when it should be 'Json'. This patch also extends the argparse setup for '--output' with available output formats.
