### PR TITLE
Suggested modification to improve reuse as library

### DIFF
--- a/otcclient/plugins/noout.py
+++ b/otcclient/plugins/noout.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of OTC Tool released under MIT license.
+# Copyright (C) 2016 T-systems Kurt Garloff, Zsolt Nagy 
+
+from otcclient.core.OtcConfig import OtcConfig 
+from otcclient.core.otcpluginbase import otcpluginbase
+from otcclient.utils import utils_output 
+
+class noout(otcpluginbase):
+    
+    def otctype(self):
+        return "utils_output" 
+    
+    @staticmethod
+    def handleQuery(result):
+        utils_output.handleQuery(result, OtcConfig.QUERY)
+                
+    @staticmethod
+    def print_output(respjson, **kwargs):
+	pass
+


### PR DESCRIPTION
### Proposal: Enable and simplify code reuse by providing an output plugin that supppresses gratuitous output

Let us assume I just need the provided OTC API related code because I do not want to track, maintain and duplicate any REST API calls, e.g. I was intending to write ansible modules in the style of already existing cloud modules like here: http://docs.ansible.com/ansible/list_of_cloud_modules.html

Unfortunately all provided output modules mess up my plans because ansible reads STDOUT and STDERR from module output and currently both do not emit anything helpful for this usecase.