### PR TITLE
removed second slash in delete_security_group function

### DIFF
--- a/otcclient/plugins/ecs/ecs.py
+++ b/otcclient/plugins/ecs/ecs.py
@@ -663,7 +663,7 @@ class ecs(otcpluginbase):
         if not (OtcConfig.SECUGROUPNAME is None):
             ecs.convertSECUGROUPNameToId()
         
-        url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2.0/" + "/security-groups" + "/"+ OtcConfig.SECUGROUP
+        url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2.0/security-groups" + "/"+ OtcConfig.SECUGROUP
         ret = utils_http.delete(url)
         return ret
 


### PR DESCRIPTION
Extra slash in url causes utils_http.delete(url) to fail for security group deletion. Note: failure is silent since delete returns with a 204 even with the debug flag