### PR TITLE
Fix ECS JSON file personalization

### DIFF
--- a/otcclient/plugins/ecs/ecs.py
+++ b/otcclient/plugins/ecs/ecs.py
@@ -417,21 +417,21 @@ class ecs(otcpluginbase):
             ar =  str(OtcConfig.FILE3).split("=")
             if len(FILECOLLECTIONJSON) > 0:
                 FILEJSONITEM = ","
-            FILEJSONITEM = ecs.getFileContentJSON(ar[1], ar[0])
+            FILEJSONITEM = FILEJSONITEM + ecs.getFileContentJSON(ar[1], ar[0])
         FILECOLLECTIONJSON = FILECOLLECTIONJSON + FILEJSONITEM
         FILEJSONITEM = ""
         if not OtcConfig.FILE4 is None:
             ar =  str(OtcConfig.FILE4).split("=")
             if len(FILECOLLECTIONJSON) > 0:
                 FILEJSONITEM = ","
-            FILEJSONITEM = ecs.getFileContentJSON(ar[1], ar[0])
+            FILEJSONITEM = FILEJSONITEM + ecs.getFileContentJSON(ar[1], ar[0])
         FILECOLLECTIONJSON = FILECOLLECTIONJSON + FILEJSONITEM
         FILEJSONITEM = ""
         if not OtcConfig.FILE5 is None:
             ar =  str(OtcConfig.FILE5).split("=")
             if len(FILECOLLECTIONJSON) > 0:
                 FILEJSONITEM = ","
-            FILEJSONITEM = ecs.getFileContentJSON(ar[1], ar[0])
+            FILEJSONITEM = FILEJSONITEM + ecs.getFileContentJSON(ar[1], ar[0])
         FILECOLLECTIONJSON = FILECOLLECTIONJSON + FILEJSONITEM
         PERSONALIZATION = ""
         if len(FILECOLLECTIONJSON) > 0:


### PR DESCRIPTION
When adding files 3-5 with the --filex flag, the call will fail from incorrect syntax in the personalization json (missing comma).

BROKEN JSON:
{ "path": "/file1", "contents": "12345" },{ "path": "/etc/file2", "contents": "12345" }{ "path": "/file3", "contents": "12345" }

RETURN ERROR:
{"error":{"message":"convert request to ServerCreateRequest fail!","code":"Ecs.0005"}}
