### PR TITLE
elb: fix describe_members

### DIFF
--- a/otcclient/plugins/elb/elb.py
+++ b/otcclient/plugins/elb/elb.py
@@ -68,10 +68,10 @@ class elb(otcpluginbase):
 
     @staticmethod
     @otcfunc(plugin_name=__name__,
-         desc="Describe listeners",
+         desc="Describe members",
          args = [
-            arg(    '--load-balancer-name',     dest='LOADBALANCER_NAME',     help='Loadbalancer name of the VM'),
-            arg(    '--load-balancer-id',     dest='LOADBALANCER_ID',     help='Loadbalancer Id of the VM') ]
+            arg(    '--listener-name',     dest='LISTENER_NAME',     help='Listener name'),
+            arg(    '--listener-id',     dest='LISTENER_ID',     help='Listener Id') ]
          )
     def describe_members():
         if not (OtcConfig.LISTENER_NAME is None):


### PR DESCRIPTION
Looks like some simple copy&paste mistake may have caused the issue. The
method was already working fine but there was no way to pass the
required parameters when invoking otcclient from CLI. Simply re-labeling
method arguments solved the issue for me.
Do you mind reviewing this change?