### PR TITLE
Replace print XY with print(XZ) for python3 compatibility.

### DIFF
--- a/otcclient/core/userconfigaction.py
+++ b/otcclient/core/userconfigaction.py
@@ -39,7 +39,7 @@ class userconfigaction(argparse.Action):
         for name, value in sorted(locals().items()):
             if name == 'self' or value is None:
                 continue
-#            print '  %s = %r' % (name, value)
+#            print('  %s = %r' % (name, value))
         return
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -50,7 +50,7 @@ class userconfigaction(argparse.Action):
         elif values:
             values = values.lower()
             OtcConfig.MAINCOM = values
-            #print values
+            #print(values)
 
         try:
             if OtcConfig.MAINCOM == "user":

--- a/otcclient/plugins/cce/cce.py
+++ b/otcclient/plugins/cce/cce.py
@@ -31,7 +31,7 @@ class cce(otcpluginbase):
     def convertClusterNameToId():
         url = "https://cce.eu-de.otc.t-systems.com" + "/api/v1/clusters"
         JSON = utils_http.get(url)
-        # print JSON        
+        # print(JSON)
         parsed  = json.loads(JSON)
         clusters = parsed
         ret = None
@@ -156,7 +156,7 @@ class cce(otcpluginbase):
         req = utils_templates.create_request("cce_create_cluster")
 
         ret = utils_http.post(url, req)
-        print ret 
+        print(ret)
         cce.otcOutputHandler().print_output(ret,mainkey="")     
         return ret
 
@@ -244,8 +244,8 @@ class cce(otcpluginbase):
             cce.convertClusterNameToId()         
         url = "https://" + OtcConfig.DEFAULT_HOST + "/api/v1/namespaces"
         req = utils_templates.create_request("create_namespace")
-        #print req
-        #print OtcConfig.NAMESPACE
+        #print(req)
+        #print(OtcConfig.NAMESPACE)
         ret = utils_http.post(url, req)
         #print (ret)
         cce.otcOutputHandler().print_output(ret,mainkey="")     
@@ -539,7 +539,7 @@ class cce(otcpluginbase):
         
         url = "https://" + OtcConfig.DEFAULT_HOST + "/api/v1/namespaces/" + OtcConfig.NAMESPACE + "/secrets"
         req = utils_templates.create_request("cce_create_secret")
-        #print req        
+        #print(req)
         ret = utils_http.post(url, req)
         cce.otcOutputHandler().print_output(ret,mainkey="")    
         return ret
@@ -610,7 +610,7 @@ class cce(otcpluginbase):
         
         url = "https://" + OtcConfig.DEFAULT_HOST + "/api/v1/namespaces/" + OtcConfig.NAMESPACE + "/replicationcontrollers"
         req = utils_templates.create_request("cce_create_rc")
-        #print req        
+        #print(req)
         ret = utils_http.post(url, req)
         cce.otcOutputHandler().print_output(ret,mainkey="")    
         return ret
@@ -635,7 +635,7 @@ class cce(otcpluginbase):
         
         url = "https://" + OtcConfig.DEFAULT_HOST + "/api/v1/namespaces/" + OtcConfig.NAMESPACE + "/replicationcontrollers/" + OtcConfig.RC_NAME
         req = utils_templates.create_request("cce_create_rc")
-        #print req        
+        #print(req)
         ret = utils_http.put(url, req)
         cce.otcOutputHandler().print_output(ret,mainkey="")    
         return ret
@@ -658,4 +658,4 @@ class cce(otcpluginbase):
         ret = utils_http.delete(url)
         cce.otcOutputHandler().print_output(ret,mainkey="")     
         return ret
-                
+

--- a/otcclient/plugins/customrep/customrep.py
+++ b/otcclient/plugins/customrep/customrep.py
@@ -46,7 +46,7 @@ class customrep(otcpluginbase):
         ret = utils_http.get(url)
         quotas = json.loads(ret)
         for q in quotas["quotas"]:
-            #print q
+            #print(q)
             pass
         #customrep.otcOutputHandler().print_output(ret, mainkey="quotas")    
     """                     
@@ -77,7 +77,7 @@ class customrep(otcpluginbase):
 
             url = "https://" + OtcConfig.DEFAULT_HOST + "/v2/" + OtcConfig.PROJECT_ID + "/servers/detail"                        
             ret = utils_http.get(url)
-            print ret
+            print(ret)
             servers = json.loads(ret)
             servercount = len(servers["servers"])
             

--- a/otcclient/plugins/ecs/ecs.py
+++ b/otcclient/plugins/ecs/ecs.py
@@ -324,7 +324,7 @@ class ecs(otcpluginbase):
                        ])
     def associate_address():
         REQ_ASSOCIATE_PUBLICIP = "{ \"publicip\": { \"port_id\": \"" + OtcConfig.NETWORKINTERFACEID + "\" } }"
-        #print REQ_ASSOCIATE_PUBLICIP
+        #print(REQ_ASSOCIATE_PUBLICIP)
         if not (OtcConfig.PUBLICIP is None):
             ecs.convertPublicIpNameToId()
 
@@ -755,7 +755,7 @@ class ecs(otcpluginbase):
         #REQ_CREATE_SECGROUPRULE = "{\"security_group_rule\":{ \"direction\":\"" + OtcConfig.DIRECTION + "\", \"port_range_min\":\"" + OtcConfig.PORTMIN  + "\", \"ethertype\":\"" + OtcConfig.ETHERTYPE + "\", \"port_range_max\":\"" ''+ OtcConfig.PORTMAX+ "\", \"protocol\":\""+ OtcConfig.PROTOCOL+ remoteGroup  + sourceIp+ "\"  , \"security_group_id\":\""+ OtcConfig.SECUGROUP + "\" } }"
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2.0/security-group-rules"
         ret = utils_http.post(url, REQ_CREATE_SECGROUPRULE)
-        #print REQ_CREATE_SECGROUPRULE
+        #print(REQ_CREATE_SECGROUPRULE)
         print (ret)
         ecs.otcOutputHandler().print_output(ret, mainkey="security_group_rule")
         return ret
@@ -861,7 +861,7 @@ class ecs(otcpluginbase):
         REQ_CREATE_VM=utils_templates.create_request("create_vm")
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v1/" + OtcConfig.PROJECT_ID + "/cloudservers"
 
-        #print REQ_CREATE_VM
+        #print(REQ_CREATE_VM)
         ret = utils_http.post(url, REQ_CREATE_VM)
         #print (ret)
         if OtcConfig.DEBUG:
@@ -960,7 +960,7 @@ class ecs(otcpluginbase):
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/cloudvolumes"
         JSON = utils_http.get(url)
         parsed  = json.loads(JSON)
-        #print JSON
+        #print(JSON)
         cloudvolumes = parsed["volumes"]
         ret = None
         for cloudvolume in cloudvolumes:
@@ -1123,7 +1123,7 @@ class ecs(otcpluginbase):
                 ])
     def create_volume():
         REQ_CREATE_CLOUDVOLUMES = "{ \"volume\": { \"backup_id\": " + OtcConfig.SNAPSHOTID + ", " + "\"count\": " + OtcConfig.NUMCOUNT + ", \"availability_zone\": \"" + OtcConfig.AZ + "\",\"description\": \"" + OtcConfig.VOLUME_NAME + "\", \"size\": " + OtcConfig.VOLUME_SIZE + ", \"name\": \"" + OtcConfig.VOLUME_NAME + "\", \"imageRef\": " + "null" + ", \"volume_type\": \"" + OtcConfig.VOLUME_TYPE + "\" } }"
-        #print REQ_CREATE_CLOUDVOLUMES
+        #print(REQ_CREATE_CLOUDVOLUMES)
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/cloudvolumes"
         ret = utils_http.post(url, REQ_CREATE_CLOUDVOLUMES)
         print(ret)
@@ -1257,7 +1257,7 @@ class ecs(otcpluginbase):
             os._exit(1)
 
         REQ_RESTORE_BACKUP = "{ \"restore\":{ \"volume_id\":\"" + OtcConfig.VOLUME_ID + "\" } }"
-        #print REQ_RESTORE_BACKUP
+        #print(REQ_RESTORE_BACKUP)
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/cloudbackups" +"/" + OtcConfig.SNAPSHOTID + "/restore"
         ret = utils_http.post(url, REQ_RESTORE_BACKUP)
         print(ret)
@@ -1302,7 +1302,7 @@ class ecs(otcpluginbase):
                 OtcConfig.DESCRIPTION = OtcConfig.VOLUME_NAME
 
         REQ_CREATE_BACKUP = "{ \"backup\":{ \"" + "volume_id\":\"" + OtcConfig.VOLUME_ID + "\", " + "\"name\":\"" + OtcConfig.DESCRIPTION + "\", \"description\":\"" + OtcConfig.DESCRIPTION + "\" } }"
-        #print REQ_CREATE_BACKUP
+        #print(REQ_CREATE_BACKUP)
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/cloudbackups"
         ret = utils_http.post(url, REQ_CREATE_BACKUP)
         print (ret)
@@ -1379,12 +1379,12 @@ class ecs(otcpluginbase):
 
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/os-vendor-tags/volumes/" + OtcConfig.INSTANCE_ID
         url = string.replace(url, 'iam', 'evs')
-        print url
+        print(url)
         ret = utils_http.get(url)
         parsed = json.loads(ret)
         print (ret)
         return
-        print parsed["tags"]
+        print(parsed["tags"])
         return parsed
 
     @staticmethod
@@ -1407,7 +1407,7 @@ class ecs(otcpluginbase):
         parsed["tags"].append(OtcConfig.TAG_PAIR)
         #print (parsed)
         new_json = json.dumps(parsed)
-        #print new_json
+        #print(new_json)
         ret = utils_http.put(url, new_json)
         print (ret)
         return ret
@@ -1432,7 +1432,7 @@ class ecs(otcpluginbase):
         parsed["tags"].remove(OtcConfig.TAG_PAIR)
         #print (parsed)
         new_json = json.dumps(parsed)
-        #print new_json
+        #print(new_json)
         ret = utils_http.put(url, new_json)
         print (ret)
         return ret
@@ -1468,10 +1468,10 @@ class ecs(otcpluginbase):
             ecs.convertVPCNameToId()
             
         req = utils_templates.create_request("create_evs_rep")
-        print req
+        print(req)
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/os-vendor-replications"        
         url = string.replace(url, 'iam', 'evs')
-        print url
+        print(url)
         ret = utils_http.post(url, req)
         print(ret)
         return ret
@@ -1724,10 +1724,10 @@ class ecs(otcpluginbase):
                 )
     def accept_evs_transfer():
         req = utils_templates.create_request("accept_evs_tr")
-        print req
+        print(req)
         url = "https://" + OtcConfig.DEFAULT_HOST+ "/v2/" + OtcConfig.PROJECT_ID + "/os-volume-transfer/" +  OtcConfig.VOLTRSF_ID + "/accept"
         url = string.replace(url, 'iam', 'evs')
-        print url
+        print(url)
         ret = utils_http.post(url, req)
         ecs.otcOutputHandler().print_output(ret, mainkey="")
         return ret

--- a/otcclient/plugins/mrs/mrs.py
+++ b/otcclient/plugins/mrs/mrs.py
@@ -76,7 +76,7 @@ class mrs(otcpluginbase):
         
         url = url.replace("iam", "mrs")        
         JSON = utils_http.get(url)
-        print JSON         
+        print(JSON)
         parsed  = json.loads(JSON)  
               
         servers = parsed["clusters"]


### PR DESCRIPTION
We want to be able to package python-otcclient for python-only systems
(such as the upcoming public openSUSE-Leap-15 image).
The code mostly has been prepared to work on py3, but apparently,
numerous print instructions (rather than functions) have slipped in.

This patch fixes it ...